### PR TITLE
Fix i18n_scope default value setting.

### DIFF
--- a/lib/command.rb
+++ b/lib/command.rb
@@ -28,8 +28,7 @@ module Command
   attr_reader :result
 
   module ClassMethods
-
-    def extended(base)
+    def self.extended(base)
       base.i18n_scope = "errors.messages"
     end
     attr_accessor :i18n_scope

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -165,6 +165,22 @@ describe Command do
     end
   end
 
+  describe ".i18n_scope" do
+    after do
+      # Resetting to prevent leaks across specs
+      command.class.i18n_scope = 'errors.messages'
+    end
+
+    it "has a default value of 'errors.messages'" do
+      expect(command.class.i18n_scope).to eq('errors.messages')
+    end
+
+    it "can be overriden" do
+      command.class.i18n_scope = 'errors.new_scope'
+      expect(command.class.i18n_scope).to eq('errors.new_scope')
+    end
+  end
+
   describe "Subcommmand mechanism" do
     pending 'TODO'
   end


### PR DESCRIPTION
Causes the issues in latest builds of TheMenu/lunchr-bank-operations#278. (`i18n_scope` ends up at `nil` => No internationalization for the errors of the command)